### PR TITLE
Masha march7

### DIFF
--- a/src/main/resources/beliefs/events.yml
+++ b/src/main/resources/beliefs/events.yml
@@ -8,130 +8,122 @@ vars: beliefs/triggers.yml
 
 rules:
 
-# Note: prop vs entity rule pairs may be redundant; todo: compare extractions, eliminate prop rules if redundant
-- name: ${label}-believe-active-believer-prop
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  pattern: |
-    trigger = [lemma=/${active_believer_triggers}/ & tag=/^V|^J/] (?![word="tank"])
-    believer:Agent = /nsubj|A0/
-    belief:Proposition = /ccomp|A1|dobj|xcomp|advcl/
+  # Note: prop vs entity rule pairs may be redundant, but the prop rules seem to capture some more complete beliefs than entity rules
+  - name: ${label}-believe-active-believer-prop
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    pattern: |
+      trigger = [lemma=/${active_believer_triggers}/ & tag=/^V|^J/] (?![word="tank"])
+      believer:Agent = /nsubj|A0/
+      belief:Proposition = /ccomp|A1|dobj|xcomp|advcl/
 
-- name: ${label}-believe-active-believer-entity
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  pattern: |
-    trigger = [lemma=/${active_believer_triggers}/ & tag=/^V|^J/] (?![word="tank"])
-    believer:Agent = /nsubj$|A0/
-    belief:Entity = /ccomp|A1|dobj|xcomp|advcl|nmod_about/
+  - name: ${label}-consider-active-believer
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    pattern: |
+      trigger = [lemma=/consider/ & tag=/^V|^J/] 
+      believer:Agent = /nsubj|A0/
+      belief:Proposition = /xcomp/
 
-- name: ${label}-believe-impersonal-believer-prop
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  pattern: |
-    trigger = [lemma=/${impersonal_belief_triggers}/ & tag=/^J|VBG|VBN/]
-    believer:Entity = /nsubj|nsubjpass|A0/ [word=/(?i)it/]
-    belief:Proposition = /ccomp|A1|dobj|xcomp|advcl|nmod_about/
+  - name: ${label}-believe-active-believer-entity
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    pattern: |
+      trigger = [lemma=/${active_believer_triggers}/ & tag=/^V|^J/] (?![word="tank"])
+      believer:Agent = /nsubj$|A0/
+      belief:Entity = /ccomp|A1|dobj|xcomp|advcl|nmod_about/
 
-- name: ${label}-believe-impersonal-believer-ent
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  pattern: |
-    trigger = [lemma=/${impersonal_belief_triggers}/ & tag=/^J|VBG|VBN/]
-    believer:Entity = /nsubj|nsubjpass/  [word=/(?i)it/]
-    belief:Entity = /ccomp|A1|dobj|xcomp|advcl|nmod_about/
+  - name: ${label}-believe-participle
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    example: "We are all worried about global warming"
+    pattern: |
+      trigger = [lemma=/${participial_belief_triggers}/ & tag=/^VBN/]
+      believer:Entity = /nsubjpass|A0/
+      belief:Entity = /nmod_about/
 
-- name: ${label}-believe-participle
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  example: "We are all worried about global warming"
-  pattern: |
-    trigger = [lemma=/${participial_belief_triggers}/ & tag=/^VBN/]
-    believer:Entity = /nsubjpass|A0/
-    belief:Entity = /nmod_about/
+  - name: ${label}-believe-split-belief
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    example: "Trump is believed to be a narcissist" # doesn't work: The rainy season starting date and seasonal forecasts are considered by farmers as the most important type of information .
+    pattern: |
+      trigger = [lemma=/think|believe|expect|consider/ & tag=/^VBN/]
+      beliefTheme:Entity = /nsubjpass|A1/
+      belief:Entity = /xcomp| nmod_as/
 
-- name: ${label}-believe-split-belief
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  example: "Trump is believed to be a narcissist"
-  pattern: |
-    trigger = [lemma=/think|believe|expect/ & tag=/^VBN/]
-    beliefTheme:Entity = /nsubjpass|A1/
-    belief:Entity = /xcomp/
+  - name: ${label}-believe-impersonal-it
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    pattern: |
+      trigger = [lemma=/^trust|believe/ & tag=/^V/]
+      believer:Entity = /nsubj|nsubjpass/  [word=/(?i)it/]
+      belief:Entity = /xcomp/
 
-- name: ${label}-believe-impersonal-it
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  pattern: |
-    trigger = [lemma=/^trust/ & tag=/^V/]
-    believer:Entity = /nsubj|nsubjpass/  [word=/(?i)it/]
-    belief:Entity = /xcomp/
+  - name: ${label}-believe-control
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    example: "I expect my investments to do well."
+    pattern: |
+      trigger = [lemma=/expect/]
+      believer:Entity = /nsubj/
+      belief:Entity = dobj| xcomp | nsubj /xsubj$/ A3
 
-- name: ${label}-believe-control
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  example: "I expect my investments to do well."
-  pattern: |
-    trigger = [lemma=/expect/]
-    believer:Entity = /nsubj/
-    belief:Entity = dobj| xcomp | nsubj /xsubj$/ A3
+  - name: ${label}-believe-willingness
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    example: "Despite farmers' willingness to diversify crop production, growing new crops is risky and self-financed."
+    pattern: |
+      trigger = [lemma=/willingness/]
+      believer:Agent = "nmod:poss"
+      belief:Entity = acl
 
-- name: ${label}-believe-willingness
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  example: "Despite farmers' willingness to diversify crop production, growing new crops is risky and self-financed."
-  pattern: |
-    trigger = [lemma=/willingness/]
-    believer:Agent = "nmod:poss"
-    belief:Entity = acl
+  - name: ${label}-believe-recognize
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    example: "The networks recognized the importance of maintaining extension services to ensure that their farmer members applied best practices."
+    pattern: |
+      trigger = [lemma=/recognize/] (?= [word = "the"] [word="importance"])
+      believer:Entity = nsubj
+      belief:Entity = dobj acl
 
-- name: ${label}-believe-recognize
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  example: "The networks recognized the importance of maintaining extension services to ensure that their farmer members applied best practices."
-  pattern: |
-    trigger = [lemma=/recognize/] (?= [word = "the"] [word="importance"])
-    believer:Entity = nsubj
-    belief:Entity = dobj acl
+  - name: ${label}-believe-stigma
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    example: "However, FEPROMAS detected a cultural norm of negative stigma attached with receiving food aid."
+    pattern: |
+      trigger = [lemma=/stigma/]
+      belief:Entity = A1 | acl advcl
 
-- name: ${label}-believe-stigma
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  example: "However, FEPROMAS detected a cultural norm of negative stigma attached with receiving food aid."
-  pattern: |
-    trigger = [lemma=/stigma/]
-    belief:Entity = A1 | acl advcl
-  #
-- name: ${label}-believe-impersonal-adj
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  pattern: |
-    trigger = [lemma=/hard|easy/] [word = "to"] [word="see"]
-    believer:Entity = /nsubj|expl/ [word=/(?i)it/]
-    belief:Entity = /ccomp|A1|dobj|xcomp/
+  - name: ${label}-popular
+    priority: ${rulepriority}
+    label: ${label}
+    type: "token"
+    example: "manual threshing is popular"
+    pattern: |
+      @beliefTheme:NounPhrase (?<trigger> [lemma = "be"]) (?<belief> [word = "popular"])
 
-- name: ${label}-believe-likely
-  priority: ${rulepriority}
-  label: ${label}
-  graph: "hybrid"
-  pattern: |
-    trigger = [lemma=/likely|unlikely/]
-    beliefTheme:Entity = /nsubj/ [!word=/(?i)(it|this)/]
-    belief:Entity = /ccomp|xcomp/
+  - name: ${label}-prefer
+    priority: ${rulepriority}
+    label: ${label}
+    graph: "hybrid"
+    example: "Abduland Salin (2005) reported that farmers preferred the modified pedal thresher to the unmodified model"
+    pattern: |
+      trigger = [lemma=/expect|want|prefer|hope/]
+      believer:Agent = nsubj
+      belief:Entity = /dobj|xcomp/
+   
 
-# Temporarily disabled, to review
+# Temporarily disabled, to review (mainly author beliefs)
 
 #- name: ${label}-believe-1
 #  priority: ${rulepriority}
@@ -181,3 +173,42 @@ rules:
 #    trigger = [lemma=/positive/]
 #    believer:Entity = /nsubj/ [word=/(?i)it/]
 #    belief:Entity = ccomp
+
+  # these are for author beliefs
+  #- name: ${label}-believe-impersonal-believer-prop
+  #  priority: ${rulepriority}
+  #  label: ${label}
+  #  graph: "hybrid"
+  #  pattern: |
+  #    trigger = [lemma=/${impersonal_belief_triggers}/ & tag=/^J|VBG|VBN/]
+  #    believer:Entity = /nsubj|nsubjpass|A0/ [word=/(?i)it/]
+  #    belief:Proposition = /ccomp|A1|dobj|xcomp|advcl|nmod_about/
+
+  #- name: ${label}-believe-impersonal-believer-ent
+  #  priority: ${rulepriority}
+  #  label: ${label}
+  #  graph: "hybrid"
+  #  pattern: |
+  #    trigger = [lemma=/${impersonal_belief_triggers}/ & tag=/^J|VBG|VBN/]
+  #    believer:Entity = /nsubj|nsubjpass/  [word=/(?i)it/]
+  #    belief:Entity = /ccomp|A1|dobj|xcomp|advcl|nmod_about/
+
+
+#- name: ${label}-believe-impersonal-adj
+#  priority: ${rulepriority}
+#  label: ${label}
+#  graph: "hybrid"
+#  pattern: |
+#    trigger = [lemma=/hard|easy/] [word = "to"] [word="see"]
+#    believer:Entity = /nsubj|expl/ [word=/(?i)it/]
+#    belief:Entity = /ccomp|A1|dobj|xcomp/
+
+# this is author's belief; even in "famers are likely to plant ...", it's the belief of the author
+#- name: ${label}-believe-likely
+#  priority: ${rulepriority}
+#  label: ${label}
+#  graph: "hybrid"
+#  pattern: |
+#    trigger = [lemma=/likely|unlikely/]
+#    beliefTheme:Entity = /nsubj/ [!word=/(?i)(it|this)/]
+#    belief:Entity = /ccomp|xcomp/

--- a/src/main/resources/beliefs/propositions.yml
+++ b/src/main/resources/beliefs/propositions.yml
@@ -2,39 +2,53 @@ vars: beliefs/triggers.yml
 
 rules:
 
-# proposition rules are intended to help capture more complete propositions/assist with expansion
+  # proposition rules are intended to help capture more complete propositions/assist with expansion
 
-- name: proposition-rule-cop
-  label: Proposition
-  priority: ${priority}
-  type: dependency
-  pattern: |
-    trigger = [lemma = "be"]
-    subj:NounPhrase = <cop nsubj
-    obj:NounPhrase = <cop
+  - name: proposition-rule-inf-nom-pred
+    label: Proposition
+    priority: ${priority}
+    type: token
+    pattern: |
+      @NounPhrase "to" "be" @AdjPhrase | @NounPhrase "to" "be" [tag = "DT"]? @NounPhrase
 
-- name: proposition-rule-expl
-  label: Proposition
-  priority: ${priority}
-  type: dependency
-  pattern: |
-    trigger = [word="there"] [lemma = "be"]
-    subj:NounPhrase = nsubj
+  - name: proposition-rule-inf-verb-pred
+    label: Proposition
+    priority: ${priority}
+    type: token
+    pattern: |
+      @NounPhrase "to" @VerbPhrase
 
-- name: proposition-rule-verb
-  label: Proposition
-  priority: ${priority}
-  type: dependency
-  pattern: |
-    trigger = (?<![word="there"]) [tag = /VB/]
-    subj:NounPhrase = nsubj
-    obj:NounPhrase? = dobj
+  - name: proposition-rule-cop
+    label: Proposition
+    priority: ${priority}
+    type: dependency
+    pattern: |
+      trigger = [lemma = "be"]
+      subj:NounPhrase = <cop nsubj
+      obj:NounPhrase = <cop
 
-- name: nested-proposition-rule
-  label: Proposition
-  priority: ${nestedPriority}
-  type: dependency
-  pattern: |
-    trigger = [lemma = "be"]
-    subj:NounPhrase = nsubj
-    obj: Proposition = ccomp
+  - name: proposition-rule-expl
+    label: Proposition
+    priority: ${priority}
+    type: dependency
+    pattern: |
+      trigger = [word="there"] [lemma = "be"]
+      subj:NounPhrase = nsubj
+
+  - name: proposition-rule-verb
+    label: Proposition
+    priority: ${priority}
+    type: dependency
+    pattern: |
+      trigger = (?<![word="there"]) [tag = /VB/]
+      subj:NounPhrase = nsubj
+      obj:NounPhrase? = dobj
+
+  - name: nested-proposition-rule
+    label: Proposition
+    priority: ${nestedPriority}
+    type: dependency
+    pattern: |
+      trigger = [lemma = "be"]
+      subj:NounPhrase = nsubj
+      obj: Proposition = ccomp

--- a/src/main/resources/variables/events-areas.yml
+++ b/src/main/resources/variables/events-areas.yml
@@ -2,19 +2,15 @@
 - name: ${label}-var-val
   priority: ${rulepriority} 
   label: ${label}
-  action: splitIfTwoValues
+  action: areaVarActionFlow
   type: token
   pattern: |
-    @variable:Variable ( [word=/.+/]{, 17}) @value:Value ( [word=/.+/]{, 17}) @value:Value
-    |
-    @variable:Variable ( [word=/.+/]{, 17} @value:Value )+  
-    |
-    @variable:Variable of @value:Value
+    @variable:Variable ( []+? @value:Value )+
 
 - name: ${label}-val-var
   priority: ${rulepriority} 
   label: ${label}
-  action: splitIfTwoValues
+  action: areaVarActionFlow
   type: token
   pattern: |
-    ( @value:Value [word=/.+/]{, 10} )+ @variable:Variable  
+    ( @value:Value []+? )+ @variable:Variable  

--- a/src/main/scala/org/clulab/habitus/actions/HabitusActions.scala
+++ b/src/main/scala/org/clulab/habitus/actions/HabitusActions.scala
@@ -66,6 +66,29 @@ class HabitusActions extends Actions {
     }
   }
 
+
+  def areaVarActionFlow(mentions: Seq[Mention]): Seq[Mention] = {
+    // applies within a rule
+    // split mentions with mult args into binary mentions
+    val split = splitIfTwoValues(mentions)
+    // filter out the ones where var and val are too far
+    limitVarValSpan(split)
+  }
+
+  def limitVarValSpan(mentions: Seq[Mention]): Seq[Mention] = {
+    val toReturn = new ArrayBuffer[Mention]()
+    for (m <- mentions) {
+      // at this point, the mentions are already binary (one var and one val)
+      val args = m.arguments.map(_._2.head).toSeq
+      val sortedArgs = args.sortBy(_.tokenInterval)
+      val distance = sortedArgs.last.start -  sortedArgs.head.end
+      if (distance <= 17) {
+        toReturn.append(m)
+      }
+    }
+    toReturn
+  }
+
   def splitIfTwoValues(mentions: Seq[Mention]): Seq[Mention] = {
     // for area rules; if there is an extraction with multiple value args,
     // split it into binary var-value mentions

--- a/src/main/scala/org/clulab/habitus/beliefs/BeliefProcessor.scala
+++ b/src/main/scala/org/clulab/habitus/beliefs/BeliefProcessor.scala
@@ -55,7 +55,7 @@ class BeliefProcessor(val processor: Processor,
     val eventTriggers = eventMentions.collect { case em: EventMention => em.trigger }
     val expandedMentions = eventMentions.map(expandArgs(_, State(eventTriggers)))
     // keep only beliefs that look like propositions
-    val propBeliefMentions = expandedMentions.filter(m => containsPropositionBelief(m) || containsPropositionBeliefWithTheme(m))
+    val propBeliefMentions = expandedMentions.filter(m => containsPropositionBelief(m) || containsPropositionBeliefWithTheme(m) || m.arguments.keys.toList.length > 2)
     val triggerFilered = triggerBetweenBelieverAndBelief(propBeliefMentions)
 
     (doc, triggerFilered.distinct)

--- a/src/test/scala/org/clulab/habitus/beliefs/TestBeliefReader.scala
+++ b/src/test/scala/org/clulab/habitus/beliefs/TestBeliefReader.scala
@@ -103,8 +103,9 @@ class TestBeliefReader extends Test {
     m.arguments("belief").head.text should be ("Tröegs might know a thing or two about beer")
   }
 
+  // Tests sent10 - sent_10_10 are author beliefs, which we are not extracting now
   val sent10 = "It's credible that Rudy Giuliani broke the law"
-  sent10 should "contain one belief" in {
+  ignore should s"contain one belief in ${sent10}" in {
     val mentions = getMentions(sent10)
     mentions should have size(1)
 
@@ -114,7 +115,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_0 = "It's not credible that Rudy Giuliani broke the law"
-  sent10_0 should "contain one belief" in {
+  ignore should s"contain one belief in ${sent10_0}" in {
     val mentions = getMentions(sent10_0)
     mentions should have size(1)
 
@@ -124,7 +125,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_1 = "It's convincing that Rudy Giuliani broke the law"
-  toDiscuss should s"contain one belief in ${sent10_1}" in {
+  ignore should s"contain one belief in ${sent10_1}" in {
     val mentions = getMentions(sent10_1)
     mentions should have size(1)
 
@@ -134,7 +135,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_2 = "It's believable that Rudy Giuliani broke the law"
-  sent10_2 should "contain one belief" in {
+  ignore should s"contain one belief in ${sent10_2}" in {
     val mentions = getMentions(sent10_2)
     mentions should have size(1)
 
@@ -144,7 +145,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_3 = "It's inconceivable that anyone would hate The Princess Bride"
-  sent10_3 should "contain one belief" in {
+  ignore should s"contain one beliefin ${sent10_3}" in {
     val mentions = getMentions(sent10_3)
     mentions should have size(1)
 
@@ -154,7 +155,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_4 = "It's suspect that Rudy Giuliani broke the law"
-  toDiscuss should s"contain one belief in ${sent10_4}" in {
+  ignore should s"contain one belief in ${sent10_4}" in {
     val mentions = getMentions(sent10_4)
     mentions should have size(1)
 
@@ -164,7 +165,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_5 = "It's plausible that Rudy Giuliani broke the law"
-  sent10_5 should "contain one belief" in {
+  ignore should s"contain one beliefin ${sent10_5}" in {
     val mentions = getMentions(sent10_5)
     mentions should have size(1)
 
@@ -174,7 +175,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_6 = "It's questionable that anyone would hate The Princess Bride"
-  sent10_6 should "contain one belief" in {
+  ignore should s"contain one beliefin ${sent10_6}" in {
     val mentions = getMentions(sent10_6)
     mentions should have size(1)
 
@@ -184,7 +185,7 @@ class TestBeliefReader extends Test {
   }
 
  val sent10_7 = "It's dubious that anyone would hate The Princess Bride"
-  sent10_7 should "contain one belief" in {
+  ignore should s"contain one beliefin ${sent10_7}" in {
     val mentions = getMentions(sent10_7)
     mentions should have size(1)
 
@@ -194,7 +195,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_8 = "It's equivocal that anyone would hate The Princess Bride"
-  toDiscuss should s"contain one belief in ${sent10_8}" in {
+  ignore should s"contain one belief in ${sent10_8}" in {
     val mentions = getMentions(sent10_8)
     mentions should have size(1)
 
@@ -204,7 +205,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_9 = "It's conclusive that anyone would hate The Princess Bride"
-  sent10_9 should "contain one belief" in {
+  ignore should s"contain one beliefin ${sent10_9}" in {
     val mentions = getMentions(sent10_9)
     mentions should have size(1)
 
@@ -214,7 +215,7 @@ class TestBeliefReader extends Test {
   }
 
   val sent10_10 = "It's false that anyone would hate The Princess Bride"
-  toDiscuss should s"contain one belief in ${sent10_10}" in {
+  ignore should s"contain one belief in ${sent10_10}" in {
     val mentions = getMentions(sent10_10)
     mentions should have size(1)
 
@@ -273,7 +274,7 @@ class TestBeliefReader extends Test {
   }
 
  val sent14_4 = "It's hard to see how burning coal helps the environment"
-  sent14_4 should "contain one belief" in {
+  ignore should s"contain one belief in ${sent14_4}" in {
     val mentions = getMentions(sent14_4)
     mentions should have size(1)
 

--- a/src/test/scala/org/clulab/habitus/variables/TestAreaReader.scala
+++ b/src/test/scala/org/clulab/habitus/variables/TestAreaReader.scala
@@ -38,10 +38,10 @@ class TestAreaReader extends FlatSpec with Matchers {
 
   }
 
-  val sent3 = "Harvests have started in some production areas of the valley, to date an area estimated at 843 ha is already harvested in  the Delta, 199 ha in Matam and 31 ha in Bakel."
+  val sent3 = "Harvests have started in some production areas of the valley, to date an area estimated at 843 ha is already harvested in  the Delta, 199 ha in Matam, 31 ha in Bakel, and 23 ha in Dagana."
   sent3 should "recognize area sizes" in {
     val areaMentions = getMentions(sent3).filter(_.label matches "Assignment")
-    areaMentions should have size (3)
+    areaMentions should have size (3) // excluding "23 ha in Dagana" - with this, we are testing exclusion of excessive var-val distances
     areaMentions.foreach({ m =>
       m.arguments("variable").head.text should include ("area") // fixme: 843 still attaches to areas because "area estimated at 843 ha" has not been extracted
     })


### PR DESCRIPTION
- fixing area rules + action to filter out mentions where var and val are too far away (those are likely false positives)
- disabling belief rules that capture mainly author beliefs until we decide what to do with those (they might be useful for interview reading, but not for scientific publications/reports reading) 
- more work on extracting propositions to use as beliefs
- adjusting the tests to take these changes into account
