### PR TITLE
redudancy action adjustment

### DIFF
--- a/src/main/resources/lexicons/CROP.tsv
+++ b/src/main/resources/lexicons/CROP.tsv
@@ -178,5 +178,5 @@ sorghum
 peanut
 corn
 vegetables
-Aiwu
-Kong Pao
+aiwu
+i kong pao

--- a/src/main/scala/org/clulab/habitus/actions/HabitusActions.scala
+++ b/src/main/scala/org/clulab/habitus/actions/HabitusActions.scala
@@ -109,8 +109,9 @@ class HabitusActions extends Actions {
   }
 
   def removeRedundantVariableMentions(mentions: Seq[Mention]): Seq[Mention] = {
+    // The action makes sure there is one variable for every value in most assignment events/relations (those that have value args); we exclude property assignments from this because one property can apply to multiple variables (e.g., They planted crop1 and crop2 (short duration))
     // The action applies to mentions extracted with var reader relation/event rules, so we exclude TBMs and include a value argument.
-    val (targetMentions, otherMentions) = mentions.partition(m => !m.isInstanceOf[TextBoundMention] && m.arguments.contains("value"))
+    val (targetMentions, otherMentions) = mentions.partition(m => !m.isInstanceOf[TextBoundMention] && m.arguments.contains("value") && m.label != "PropertyAssignment")
     val targetMentionGroups = targetMentions.groupBy { m => (m.sentence, m.label, m.arguments("value").head.text) }
     // If there are multiple mentions in the same group, pick the "closest" one.
     val closestTargetMentions = targetMentionGroups.toSeq.map { case (_, ms) => closestVar(ms) }


### PR DESCRIPTION
Avoid applying redundancy action to property assignments because same property can apply to multiple variables. Example:

Farmers used four indica cultivars: Aiwu (short duration, slender grain), I Kong Pao (short duration, bold grain) and IR1529 and Jaya (medium duration, slender grain).

Medium duration and slender grain will attach to both IR1529 and Jaya. 

Note: a better fix will need to happen eventually when all mention types are solidified. 
