### PR TITLE
splitting planting dates into binary events

### DIFF
--- a/src/main/resources/variables/events.yml
+++ b/src/main/resources/variables/events.yml
@@ -90,6 +90,7 @@
 - name: planting-date-cop-1
   priority: ${rulepriority}
   label: PlantingDate
+  action: splitIntoBinary
   type: token
   pattern: |
     @variable:Planting [tag=/VBN|IN/]? (?<trigger> [lemma=be]) (","? @value:Date)+ ","? ("and" @value:Date)?
@@ -113,6 +114,7 @@
 - name: planting-date-cop-8
   priority: ${rulepriority}
   label: PlantingDate
+  action: splitIntoBinary
   Example: sowing was done on 25th October
   type: token
   pattern: |
@@ -129,6 +131,7 @@
 - name: planting-date-parenthesis-1
   priority: ${rulepriority}
   label: PlantingDate
+  action: splitIntoBinary
   type: token
   pattern: |
     @variable:Planting [! (mention = "Date")]{, 4} (?<trigger> [lemma="("]) @value:Date (("," | "and")* @value:Date)*


### PR DESCRIPTION
- there was another event that could have multiple values. That was interfering with this https://github.com/clulab/habitus/blob/36fb503755a4916ebad62fa3da958f7b72bd6dea/src/main/scala/org/clulab/habitus/utils/DefaultContextExtractor.scala#L94 and also could not be printed well in the tsv