### PR TITLE
measurements fix

### DIFF
--- a/src/main/resources/variables/entities.yml
+++ b/src/main/resources/variables/entities.yml
@@ -170,7 +170,7 @@
   type: token
   action: appropriateMeasurement
   pattern: |
-    [entity='B-MEASUREMENT' & !word = /19[0-6]\d/] [entity = 'I-MEASUREMENT' & !word = /19[0-6]\d/]*
+    [entity=/B-MEASUREMENT/ & !word = /19[0-6]\d/] [entity = /I-MEASUREMENT/ & !word = /19[0-6]\d/]*
 
 - name: measurement-rule-constructed
   priority: ${rulepriority}
@@ -179,7 +179,7 @@
   example: "from 92 ( slightly N-deficient fields ) to 152 kg / ha"
   action: adjustQuantityNorm
   pattern: |
-    "from" (?<value1>[tag = "CD"]) "(" []{1,3} ")" "to" (?<value2>[entity='B-MEASUREMENT'])  (?<unit>[entity = 'I-MEASUREMENT']+)
+    "from" (?<value1>[tag = "CD"]) "(" []{1,3} ")" "to" (?<value2>[entity=/B-MEASUREMENT/])  (?<unit>[entity = /I-MEASUREMENT/]+)
 
 - name: area-size-entity-rule
   priority: ${rulepriority}
@@ -187,7 +187,7 @@
   type: token
   action: appropriateMeasurement
   pattern: |
-    (?<![word = /^vs\.?|against|compared|^forecast/][word=/\w*/]{0,3}) [entity='B-MEASUREMENT' & !word = "-"] [entity='I-MEASUREMENT']*
+    (?<![word = /^vs\.?|against|compared|^forecast/][word=/\w*/]{0,3}) [entity=/B-MEASUREMENT/ & !word = "-"] [entity=/I-MEASUREMENT/]*
 
 - name: percentage-rule
   priority: ${rulepriority}

--- a/src/main/resources/variables/events.yml
+++ b/src/main/resources/variables/events.yml
@@ -336,6 +336,6 @@
   action: makeEventFromSplitUnit
   example: "P and K concentrations in irrigation and floodwater were estimated at 0.1 mg P l-1 and 3.2 mg K l-1"
   pattern: |
-    (?<number>[entity='B-MEASUREMENT']) (?<unit1>[entity = 'I-MEASUREMENT']*)  (?<fertilizer> [entity = 'B-FERTILIZER'])  (?<unit2>[word=/\w\-1/])
+    (?<number>[entity=/B-MEASUREMENT/]) (?<unit1>[entity = /I-MEASUREMENT/]*)  (?<fertilizer> [entity = 'B-FERTILIZER'])  (?<unit2>[word=/\w\-1/])
     |
-    (?<number>[entity='B-MEASUREMENT' & tag = "CD"]) (?<unit1>[entity = 'I-MEASUREMENT'])  (?<fertilizer> [tag = /^NN/] )  (?<unit2>[word=/\w\-1/])
+    (?<number>[entity=/B-MEASUREMENT/ & tag = "CD"]) (?<unit1>[entity = /I-MEASUREMENT/])  (?<fertilizer> [tag = /^NN/] )  (?<unit2>[word=/\w\-1/])


### PR DESCRIPTION
- adjusted rules to allow measurements with complex labels (incl. unit class) to account for changes in processors
- should work with both processors 8.5.2 and 8.5.3
- in future, might need to add negative constraints on some measurements (e.g., !entity='.-MEASUREMENT-<CLASS>'), but for now no tests seem to fail